### PR TITLE
Add test that cancels an MSI package in the OnProgress for the package

### DIFF
--- a/src/WixToolsetTest.BurnE2E/FailureTests.cs
+++ b/src/WixToolsetTest.BurnE2E/FailureTests.cs
@@ -44,5 +44,23 @@ namespace WixToolsetTest.BurnE2E
             packageA.VerifyInstalled(false);
             packageB.VerifyInstalled(false);
         }
+
+        [Fact]
+        public void CanCancelMsiPackageInOnProgress()
+        {
+            var packageA = this.CreatePackageInstaller("PackageA");
+            var packageB = this.CreatePackageInstaller("PackageB");
+            var bundleA = this.CreateBundleInstaller("BundleA");
+            var testBAController = this.CreateTestBAController();
+
+            // Cancel package B during its OnProgress message.
+            testBAController.SetPackageCancelOnProgressAtProgress("PackageB", 100);
+
+            bundleA.Install((int)MSIExec.MSIExecReturnCode.ERROR_INSTALL_USEREXIT);
+            bundleA.VerifyUnregisteredAndRemovedFromPackageCache();
+
+            packageA.VerifyInstalled(false);
+            packageB.VerifyInstalled(false);
+        }
     }
 }

--- a/src/WixToolsetTest.BurnE2E/TestBAController.cs
+++ b/src/WixToolsetTest.BurnE2E/TestBAController.cs
@@ -81,6 +81,26 @@ namespace WixToolsetTest.BurnE2E
         }
 
         /// <summary>
+        /// Cancels the execute of a package at the next progess after the specified MSI action start.
+        /// </summary>
+        /// <param name="packageId">Package identity.</param>
+        /// <param name="actionName">Sets or removes the cancel progress on a package being executed.</param>
+        public void SetPackageCancelExecuteAtActionStart(string packageId, string actionName)
+        {
+            this.SetPackageState(packageId, "CancelExecuteAtActionStart", actionName);
+        }
+
+        /// <summary>
+        /// Cancels the execute of a package at a particular OnProgress point.
+        /// </summary>
+        /// <param name="packageId">Package identity.</param>
+        /// <param name="cancelPoint">Sets or removes the cancel OnProgress point on a package being executed.</param>
+        public void SetPackageCancelOnProgressAtProgress(string packageId, int? cancelPoint)
+        {
+            this.SetPackageState(packageId, "CancelOnProgressAtProgress", cancelPoint.HasValue ? cancelPoint.ToString() : null);
+        }
+
+        /// <summary>
         /// Sets the requested state for a package that the TestBA will return to the engine during plan.
         /// </summary>
         /// <param name="packageId">Package identity.</param>


### PR DESCRIPTION
This makes it cancel after the MSI install completed but before Burn considers the package complete, which needs to cause Burn to roll it back (https://github.com/wixtoolset/issues/issues/3089).

Also add more logging in TestBA when it does non-standard stuff.